### PR TITLE
Update javadoc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Public repository for contributing to the JDA readthedocs documentation.
 
 
-##Warning
+## Warning
 This is very outdated! Much of this works completely different now!
 
-Use the [javadoc](http://home.dv8tion.net:8080/job/JDA/lastCompletedBuild/javadoc/) and the [examples](https://github.com/DV8FromTheWorld/JDA/tree/master/src/examples/java) instead.
+Use the [javadoc](https://ci.dv8tion.net/job/JDA/javadoc/) and the [examples](https://github.com/DV8FromTheWorld/JDA/tree/master/src/examples/java) instead.


### PR DESCRIPTION
This repo is the first google result for "jda docs" for me, so this might be helpful to a few others too.

Also added a space to please github's markdown.